### PR TITLE
Added onMouseHover and onMouseOut options

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -55,6 +55,7 @@ RegisterNetEvent('qbr-menu:client:closeMenu', function()
     closeMenu()
 end)
 
+
 -- NUI Callbacks
 
 RegisterNUICallback('clickedButton', function(option)
@@ -81,6 +82,52 @@ RegisterNUICallback('clickedButton', function(option)
         end
     end
 end)
+
+RegisterNUICallback('mouseOver', function(option)
+    PlaySoundFrontend(-1, 'NAV_UP_DOWN', 'HUD_FRONTEND_DEFAULT_SOUNDSET', 1)
+    if not sendData then return end 
+    local data = sendData[tonumber(option)]
+    if not data then return end 
+    local onMouseOver = data.onMouseOver
+    if not onMouseOver then return end
+    local event = onMouseOver.event
+    if event then 
+        if onMouseOver.isServer then
+            TriggerServerEvent(event, onMouseOver.args)
+        elseif onMouseOver.isCommand then
+            ExecuteCommand(event)
+        elseif onMouseOver.isQBCommand then
+            TriggerServerEvent('QBCore:CallCommand', event, onMouseOver.args)
+        elseif onMouseOver.isAction then
+            event(onMouseOver.args)
+        else
+            TriggerEvent(event, onMouseOver.args)
+        end
+    end
+end)
+
+RegisterNUICallback('mouseOut', function(option)
+    if not sendData then return end 
+    local data = sendData[tonumber(option)]
+    if not data then return end 
+    local onMouseOut = data.onMouseOut
+    if not onMouseOut then return end
+    local event = onMouseOut.event
+    if  event then 
+        if onMouseOut.isServer then
+            TriggerServerEvent(event, onMouseOut.args)
+        elseif onMouseOut.isCommand then
+            ExecuteCommand(event)
+        elseif onMouseOut.isQBCommand then
+            TriggerServerEvent('QBCore:CallCommand', event, onMouseOut.args)
+        elseif onMouseOut.isAction then
+            event(onMouseOut.args)
+        else
+            TriggerEvent(event, onMouseOut.args)
+        end
+    end
+end)
+   
 
 RegisterNUICallback('closeMenu', function()
     headerShown = false

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,10 +1,12 @@
 
 local headerShown = false
 local sendData = nil
+local closeFunction = nil
 local sharedItems = exports['qbr-core']:GetItems()
 -- Functions
 
-local function openMenu(data)
+local function openMenu(data, onClose)
+
     if not data or not next(data) then return end
 	for _,v in pairs(data) do
 		if v["icon"] then
@@ -24,6 +26,8 @@ local function openMenu(data)
         action = 'OPEN_MENU',
         data = table.clone(data)
     })
+    closeFunction = onClose
+
 end
 
 local function closeMenu()
@@ -47,8 +51,8 @@ end
 
 -- Events
 
-RegisterNetEvent('qbr-menu:client:openMenu', function(data)
-    openMenu(data)
+RegisterNetEvent('qbr-menu:client:openMenu', function(data, onClose)
+    openMenu(data, onClose)
 end)
 
 RegisterNetEvent('qbr-menu:client:closeMenu', function()
@@ -127,12 +131,17 @@ RegisterNUICallback('mouseOut', function(option)
         end
     end
 end)
-   
 
 RegisterNUICallback('closeMenu', function()
     headerShown = false
     sendData = nil
     SetNuiFocus(false)
+    if closeFunction then
+        pcall(function()
+             closeFunction()
+        end)
+    end
+    closeFunction = nil
 end)
 
 -- Command and Keymapping

--- a/html/script.js
+++ b/html/script.js
@@ -22,6 +22,20 @@ const openMenu = (data = null) => {
             postData(target.attr('id'));
         }
     });
+
+    $('.button').mouseover(function() {
+        const target = $(this)
+        if (!target.hasClass('title') && !target.hasClass('disabled')) {
+            mouseOver(target.attr('id'));
+        }
+    });
+
+    $('.button').mouseout(function() {
+        const target = $(this)
+        if (!target.hasClass('title') && !target.hasClass('disabled')) {
+            mouseOut(target.attr('id'));
+        }
+    });
 };
 
 const getButtonRender = (header, message = null, id, isMenuHeader, isDisabled, icon) => {
@@ -44,6 +58,14 @@ const closeMenu = () => {
 const postData = (id) => {
     $.post(`https://${GetParentResourceName()}/clickedButton`, JSON.stringify(parseInt(id) + 1));
     return closeMenu();
+};
+
+const mouseOver = (id) => {
+    $.post(`https://${GetParentResourceName()}/mouseOver`, JSON.stringify(parseInt(id) + 1));
+};
+
+const mouseOut = (id) => {
+    $.post(`https://${GetParentResourceName()}/mouseOut`, JSON.stringify(parseInt(id) + 1));
 };
 
 const cancelMenu = () => {


### PR DESCRIPTION
Allows the developer to trigger an event/command on mouse hover and on mouse out (mouse leaves option frame). 
Same options as onclicked. Maybe not a good idea to be able to trigger server events but let me know what you think